### PR TITLE
full null check $contact_config

### DIFF
--- a/src/Http/Controllers/Overt/Contact/PluginController.php
+++ b/src/Http/Controllers/Overt/Contact/PluginController.php
@@ -38,7 +38,7 @@ class PluginController extends Controller
         }
 
         $data['isAntispam'] = $isAntispam;
-        $data['key_site'] = $contact_config['key_site'];
+        $data['key_site'] = $contact_config ? $contact_config['key_site'] ?? null : null;
         return $this->view('omega-plugin-bundle::overt.contact.display')->with($data);
     }
 


### PR DESCRIPTION
full null check on $contact_config['site_key'] that can cause an error if no captcha key entered